### PR TITLE
Replace table chart with pie chart

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -9,7 +9,10 @@ export default [
     files: ['**/*.{js,jsx}'],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/frontend/src/components/PortfolioChart.jsx
+++ b/frontend/src/components/PortfolioChart.jsx
@@ -1,27 +1,39 @@
 import React from 'react';
-import { deleteAsset } from '../api';
+import { Pie } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  ArcElement,
+  Tooltip,
+  Legend
+} from 'chart.js';
 
-export default function PortfolioTable({ data, onDelete }) {
-  return (
-    <table>
-      <thead>
-        <tr>
-          <th>Symbol</th><th>Qty</th><th>Buy $</th><th>Now $</th><th>Value $</th><th>P/L $</th><th>Action</th>
-        </tr>
-      </thead>
-      <tbody>
-        {data.map(item => (
-          <tr key={item.id}>
-            <td>{item.symbol}</td>
-            <td>{item.quantity}</td>
-            <td>{item.buy_price}</td>
-            <td>{item.current_price}</td>
-            <td>{item.current_value}</td>
-            <td style={{color: item.profit_loss >= 0 ? 'green' : 'red'}}>{item.profit_loss}</td>
-            <td><button onClick={() => { deleteAsset(item.id); onDelete(); }}>❌</button></td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  );
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+export default function PortfolioChart({ data }) {
+  const chartData = {
+    labels: data.map((item) => item.symbol.toUpperCase()),
+    datasets: [
+      {
+        data: data.map((item) => item.current_value),
+        backgroundColor: [
+          '#FF6384',
+          '#36A2EB',
+          '#FFCE56',
+          '#4BC0C0',
+          '#9966FF',
+          '#FF9F40'
+        ],
+      },
+    ],
+  };
+
+  const options = {
+    plugins: {
+      legend: {
+        position: 'bottom',
+      },
+    },
+  };
+
+  return <Pie data={chartData} options={options} />;
 }


### PR DESCRIPTION
## Summary
- render a pie chart instead of the duplicate table
- allow ESLint to run on `vite.config.js` by exposing Node globals

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846762dd414832cb3abe4de6bc63e6b