### PR TITLE
Handle missing asset in delete endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -42,6 +42,8 @@ def add_portfolio_item():
 @app.route('/portfolio/<int:item_id>', methods=['DELETE'])
 def delete_portfolio_item(item_id):
     item = PortfolioItem.query.get(item_id)
+    if item is None:
+        return jsonify({"error": "Asset not found"}), 404
     db.session.delete(item)
     db.session.commit()
     return jsonify({"message": "Asset removed"})


### PR DESCRIPTION
## Summary
- return 404 if a portfolio item doesn't exist when calling DELETE /portfolio/<id>

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684677d2e680832ca8c1d2356139f731