### PR TITLE
Fix README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,12 @@ python -m venv venv
 # source venv/bin/activate  # macOS/Linux
 pip install -r requirements.txt
 python app.py
+```
+
+### Frontend (React/Vite)
+
+```bash
+cd frontend
+npm install
+npm run dev
+```


### PR DESCRIPTION
## Summary
- close the backend setup code block in the README
- document how to start the frontend

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684678519098832c9fe18c7e15da37f3