### PR TITLE
Add validation to AddAssetForm

### DIFF
--- a/frontend/src/components/AddAssetForm.jsx
+++ b/frontend/src/components/AddAssetForm.jsx
@@ -5,11 +5,28 @@ export default function AddAssetForm({ onAdd }) {
   const [symbol, setSymbol] = useState('');
   const [quantity, setQuantity] = useState('');
   const [buyPrice, setBuyPrice] = useState('');
+  const [errors, setErrors] = useState({ quantity: false, buyPrice: false });
+  const [errorMsg, setErrorMsg] = useState('');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+
+    const qty = parseFloat(quantity);
+    const price = parseFloat(buyPrice);
+    const newErrors = {
+      quantity: isNaN(qty) || qty <= 0,
+      buyPrice: isNaN(price) || price <= 0,
+    };
+    setErrors(newErrors);
+
+    if (newErrors.quantity || newErrors.buyPrice) {
+      setErrorMsg('Quantity and buy price must be positive numbers.');
+      return;
+    }
+
+    setErrorMsg('');
     const normalizedSymbol = symbol.trim().toLowerCase();
-    await addAsset({ symbol: normalizedSymbol, quantity: parseFloat(quantity), buy_price: parseFloat(buyPrice) });
+    await addAsset({ symbol: normalizedSymbol, quantity: qty, buy_price: price });
     onAdd();
     setSymbol('');
     setQuantity('');
@@ -18,10 +35,30 @@ export default function AddAssetForm({ onAdd }) {
 
   return (
     <form onSubmit={handleSubmit}>
-      <input placeholder="Symbol (e.g. bitcoin - lowercase)" value={symbol} onChange={e => setSymbol(e.target.value)} required />
-      <input placeholder="Quantity" type="number" value={quantity} onChange={e => setQuantity(e.target.value)} required />
-      <input placeholder="Buy Price" type="number" value={buyPrice} onChange={e => setBuyPrice(e.target.value)} required />
+      <input
+        placeholder="Symbol (e.g. bitcoin - lowercase)"
+        value={symbol}
+        onChange={e => setSymbol(e.target.value)}
+        required
+      />
+      <input
+        placeholder="Quantity"
+        type="number"
+        value={quantity}
+        onChange={e => setQuantity(e.target.value)}
+        className={errors.quantity ? 'input-error' : ''}
+        required
+      />
+      <input
+        placeholder="Buy Price"
+        type="number"
+        value={buyPrice}
+        onChange={e => setBuyPrice(e.target.value)}
+        className={errors.buyPrice ? 'input-error' : ''}
+        required
+      />
       <button type="submit">Add Asset</button>
+      {errorMsg && <p className="error-message">{errorMsg}</p>}
     </form>
   );
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -71,3 +71,13 @@ td button:hover {
   max-width: 600px;
   margin: 0 auto;
 }
+
+.input-error {
+  border-color: red;
+}
+
+.error-message {
+  color: red;
+  width: 100%;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- validate quantity and buy price before submitting AddAssetForm
- show inline error message when validation fails
- highlight invalid fields in red

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846798c8270832ca78c31ff509ea38b