### PR TITLE
Add toast notifications for portfolio actions

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,8 @@
         "chart.js": "^4.4.9",
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-toastify": "^11.0.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -1690,6 +1691,15 @@
         "pnpm": ">=8"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3316,6 +3326,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/resolve-from": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "chart.js": "^4.4.9",
     "react": "^19.1.0",
     "react-chartjs-2": "^5.3.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-toastify": "^11.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { getPortfolio } from './api';
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import AddAssetForm from './components/AddAssetForm';
 import PortfolioTable from './components/PortfolioTable';
 import PortfolioChart from './components/PortfolioChart';
@@ -10,8 +12,13 @@ function App() {
   const [portfolio, setPortfolio] = useState([]);
 
   const fetchData = async () => {
-    const res = await getPortfolio();
-    setPortfolio(res.data);
+    try {
+      const res = await getPortfolio();
+      setPortfolio(res.data);
+    } catch (err) {
+      console.error(err);
+      toast.error('Failed to fetch portfolio');
+    }
   };
 
   useEffect(() => {
@@ -24,6 +31,7 @@ function App() {
       <AddAssetForm onAdd={fetchData} />
       <PortfolioTable data={portfolio} onDelete={fetchData} />
       <PortfolioChart data={portfolio} />
+      <ToastContainer position="top-center" />
     </div>
   );
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,7 +1,31 @@
 import axios from 'axios';
+import { toast } from 'react-toastify';
 
 const API = 'http://localhost:5000/portfolio';
 
-export const getPortfolio = () => axios.get(API);
-export const addAsset = (data) => axios.post(API, data);
-export const deleteAsset = (id) => axios.delete(`${API}/${id}`);
+export const getPortfolio = async () => {
+  try {
+    return await axios.get(API);
+  } catch (err) {
+    toast.error('Failed to fetch portfolio');
+    throw err;
+  }
+};
+
+export const addAsset = async (data) => {
+  try {
+    return await axios.post(API, data);
+  } catch (err) {
+    toast.error('Failed to add asset');
+    throw err;
+  }
+};
+
+export const deleteAsset = async (id) => {
+  try {
+    return await axios.delete(`${API}/${id}`);
+  } catch (err) {
+    toast.error('Failed to remove asset');
+    throw err;
+  }
+};

--- a/frontend/src/components/AddAssetForm.jsx
+++ b/frontend/src/components/AddAssetForm.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { addAsset } from '../api';
+import { toast } from 'react-toastify';
 
 export default function AddAssetForm({ onAdd }) {
   const [symbol, setSymbol] = useState('');
@@ -26,11 +27,17 @@ export default function AddAssetForm({ onAdd }) {
 
     setErrorMsg('');
     const normalizedSymbol = symbol.trim().toLowerCase();
-    await addAsset({ symbol: normalizedSymbol, quantity: qty, buy_price: price });
-    onAdd();
-    setSymbol('');
-    setQuantity('');
-    setBuyPrice('');
+    try {
+      await addAsset({ symbol: normalizedSymbol, quantity: qty, buy_price: price });
+      toast.success('Asset added');
+      onAdd();
+      setSymbol('');
+      setQuantity('');
+      setBuyPrice('');
+    } catch (err) {
+      console.error(err);
+      toast.error('Failed to add asset');
+    }
   };
 
   return (

--- a/frontend/src/components/PortfolioTable.jsx
+++ b/frontend/src/components/PortfolioTable.jsx
@@ -1,7 +1,19 @@
 import React from 'react';
 import { deleteAsset } from '../api';
+import { toast } from 'react-toastify';
 
 export default function PortfolioTable({ data, onDelete }) {
+  const handleDelete = async (id) => {
+    try {
+      await deleteAsset(id);
+      toast.success('Asset removed');
+      onDelete();
+    } catch (err) {
+      console.error(err);
+      toast.error('Failed to remove asset');
+    }
+  };
+
   return (
     <table>
       <thead>
@@ -18,7 +30,7 @@ export default function PortfolioTable({ data, onDelete }) {
             <td>{item.current_price}</td>
             <td>{item.current_value}</td>
             <td style={{color: item.profit_loss >= 0 ? 'green' : 'red'}}>{item.profit_loss}</td>
-            <td><button onClick={() => { deleteAsset(item.id); onDelete(); }}>❌</button></td>
+            <td><button onClick={() => handleDelete(item.id)}>❌</button></td>
           </tr>
         ))}
       </tbody>


### PR DESCRIPTION
## Summary
- use `react-toastify` for toast messages
- display success messages on add & delete
- show error messages for failed API calls

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68467a367880832ca20a25a4309c038b