### PR TITLE
Add edit endpoint and frontend editing

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -48,6 +48,19 @@ def delete_portfolio_item(item_id):
     db.session.commit()
     return jsonify({"message": "Asset removed"})
 
+@app.route('/portfolio/<int:item_id>', methods=['PUT'])
+def update_portfolio_item(item_id):
+    data = request.json
+    item = PortfolioItem.query.get(item_id)
+    if item is None:
+        return jsonify({"error": "Asset not found"}), 404
+    if 'quantity' in data:
+        item.quantity = data['quantity']
+    if 'buy_price' in data:
+        item.buy_price = data['buy_price']
+    db.session.commit()
+    return jsonify({"message": "Asset updated"})
+
 if __name__ == '__main__':
     with app.app_context():
         db.create_all()

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -29,7 +29,7 @@ function App() {
     <div style={{ padding: '2rem' }}>
       <h1>💰 Crypto Portfolio Visualizer</h1>
       <AddAssetForm onAdd={fetchData} />
-      <PortfolioTable data={portfolio} onDelete={fetchData} />
+      <PortfolioTable data={portfolio} onDelete={fetchData} onUpdate={fetchData} />
       <PortfolioChart data={portfolio} />
       <ToastContainer position="top-center" />
     </div>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -29,3 +29,12 @@ export const deleteAsset = async (id) => {
     throw err;
   }
 };
+
+export const updateAsset = async (id, data) => {
+  try {
+    return await axios.put(`${API}/${id}`, data);
+  } catch (err) {
+    toast.error('Failed to update asset');
+    throw err;
+  }
+};

--- a/frontend/src/components/EditAssetForm.jsx
+++ b/frontend/src/components/EditAssetForm.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import { updateAsset } from '../api';
+import { toast } from 'react-toastify';
+
+export default function EditAssetForm({ item, onUpdate, onCancel }) {
+  const [quantity, setQuantity] = useState(item.quantity);
+  const [buyPrice, setBuyPrice] = useState(item.buy_price);
+  const [errors, setErrors] = useState({ quantity: false, buyPrice: false });
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const qty = parseFloat(quantity);
+    const price = parseFloat(buyPrice);
+    const newErrors = {
+      quantity: isNaN(qty) || qty <= 0,
+      buyPrice: isNaN(price) || price <= 0,
+    };
+    setErrors(newErrors);
+    if (newErrors.quantity || newErrors.buyPrice) {
+      setErrorMsg('Quantity and buy price must be positive numbers.');
+      return;
+    }
+
+    setErrorMsg('');
+    try {
+      await updateAsset(item.id, { quantity: qty, buy_price: price });
+      toast.success('Asset updated');
+      onUpdate();
+      onCancel();
+    } catch (err) {
+      console.error(err);
+      toast.error('Failed to update asset');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        placeholder="Quantity"
+        type="number"
+        value={quantity}
+        onChange={(e) => setQuantity(e.target.value)}
+        className={errors.quantity ? 'input-error' : ''}
+        required
+      />
+      <input
+        placeholder="Buy Price"
+        type="number"
+        value={buyPrice}
+        onChange={(e) => setBuyPrice(e.target.value)}
+        className={errors.buyPrice ? 'input-error' : ''}
+        required
+      />
+      <button type="submit">Save</button>
+      <button type="button" onClick={onCancel}>Cancel</button>
+      {errorMsg && <p className="error-message">{errorMsg}</p>}
+    </form>
+  );
+}
+

--- a/frontend/src/components/PortfolioTable.jsx
+++ b/frontend/src/components/PortfolioTable.jsx
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { deleteAsset } from '../api';
 import { toast } from 'react-toastify';
+import EditAssetForm from './EditAssetForm';
 
-export default function PortfolioTable({ data, onDelete }) {
+export default function PortfolioTable({ data, onDelete, onUpdate }) {
+  const [editing, setEditing] = useState(null);
+
   const handleDelete = async (id) => {
     try {
       await deleteAsset(id);
@@ -14,26 +17,42 @@ export default function PortfolioTable({ data, onDelete }) {
     }
   };
 
+  const startEdit = (item) => {
+    setEditing(item);
+  };
+
+  const cancelEdit = () => {
+    setEditing(null);
+  };
+
   return (
-    <table>
-      <thead>
-        <tr>
-          <th>Symbol</th><th>Qty</th><th>Buy $</th><th>Now $</th><th>Value $</th><th>P/L $</th><th>Action</th>
-        </tr>
-      </thead>
-      <tbody>
-        {data.map(item => (
-          <tr key={item.id}>
-            <td>{item.symbol}</td>
-            <td>{item.quantity}</td>
-            <td>{item.buy_price}</td>
-            <td>{item.current_price}</td>
-            <td>{item.current_value}</td>
-            <td style={{color: item.profit_loss >= 0 ? 'green' : 'red'}}>{item.profit_loss}</td>
-            <td><button onClick={() => handleDelete(item.id)}>❌</button></td>
+    <div>
+      {editing && (
+        <EditAssetForm item={editing} onUpdate={onUpdate} onCancel={cancelEdit} />
+      )}
+      <table>
+        <thead>
+          <tr>
+            <th>Symbol</th><th>Qty</th><th>Buy $</th><th>Now $</th><th>Value $</th><th>P/L $</th><th>Action</th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {data.map(item => (
+            <tr key={item.id}>
+              <td>{item.symbol}</td>
+              <td>{item.quantity}</td>
+              <td>{item.buy_price}</td>
+              <td>{item.current_price}</td>
+              <td>{item.current_value}</td>
+              <td style={{color: item.profit_loss >= 0 ? 'green' : 'red'}}>{item.profit_loss}</td>
+              <td>
+                <button onClick={() => startEdit(item)}>✏️</button>
+                <button onClick={() => handleDelete(item.id)}>❌</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- enable updates for portfolio items via new PUT endpoint
- provide updateAsset API helper
- add EditAssetForm component
- show edit button in portfolio table
- refresh portfolio after updates

## Testing
- `npm run lint`
- `npm run build`
- `python -m py_compile backend/app.py backend/models.py backend/services/coingecko.py`


------
https://chatgpt.com/codex/tasks/task_e_68467b3ece3c832c9b390a0413fa3038