### PR TITLE
Use env var for API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ python app.py
 
 ```bash
 cd frontend
+cp .env.example .env  # configure VITE_API_URL if needed
 npm install
 npm run dev
 ```

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000/portfolio

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { toast } from 'react-toastify';
 
-const API = 'http://localhost:5000/portfolio';
+const API = import.meta.env.VITE_API_URL;
 
 export const getPortfolio = async () => {
   try {


### PR DESCRIPTION
## Summary
- load API URL from `import.meta.env.VITE_API_URL`
- document `VITE_API_URL` in `.env.example`
- update README with instructions for using `.env`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68467c24a338832c92bdeacb4b28c506