### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -81,3 +81,21 @@ td button:hover {
   width: 100%;
   text-align: center;
 }
+
+@media (max-width: 600px) {
+  form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  form input,
+  form button {
+    width: 100%;
+  }
+
+  table {
+    display: block;
+    overflow-x: auto;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add mobile media query in styles.css to stack form inputs
- make the portfolio table horizontally scrollable on narrow screens

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68467dd7ccdc832ca97001a1b379a229