### PR TITLE
Add coin list API and autocomplete feature

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,12 +1,18 @@
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 from models import db, PortfolioItem
-from services.coingecko import get_price
+from services.coingecko import get_price, get_coin_list
 
 app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///database.db'
 db.init_app(app)
 CORS(app)
+
+
+@app.route('/coins', methods=['GET'])
+def get_coins():
+    coins = get_coin_list()
+    return jsonify(coins)
 
 @app.route('/portfolio', methods=['GET'])
 def get_portfolio():

--- a/backend/services/coingecko.py
+++ b/backend/services/coingecko.py
@@ -19,3 +19,21 @@ def get_price(symbol):
         logger.exception("Error fetching price from CoinGecko: %s", exc)
         return 0.0
     return data.get(symbol, {}).get("usd", 0.0)
+
+
+def get_coin_list():
+    """Return list of all supported coins from CoinGecko."""
+    url = "https://api.coingecko.com/api/v3/coins/list"
+    try:
+        res = requests.get(url, timeout=10)
+        if res.status_code != 200:
+            logger.error(
+                "CoinGecko request failed with status %s: %s",
+                res.status_code,
+                res.text,
+            )
+            return []
+        return res.json()
+    except requests.RequestException as exc:
+        logger.exception("Error fetching coin list from CoinGecko: %s", exc)
+        return []

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { toast } from 'react-toastify';
 
 const API = import.meta.env.VITE_API_URL;
+const COINS_API = API.replace(/\/portfolio$/, '') + '/coins';
 
 export const getPortfolio = async () => {
   try {
@@ -35,6 +36,15 @@ export const updateAsset = async (id, data) => {
     return await axios.put(`${API}/${id}`, data);
   } catch (err) {
     toast.error('Failed to update asset');
+    throw err;
+  }
+};
+
+export const getCoins = async () => {
+  try {
+    return await axios.get(COINS_API);
+  } catch (err) {
+    toast.error('Failed to fetch coins');
     throw err;
   }
 };

--- a/frontend/src/components/AddAssetForm.jsx
+++ b/frontend/src/components/AddAssetForm.jsx
@@ -1,13 +1,26 @@
-import React, { useState } from 'react';
-import { addAsset } from '../api';
+import React, { useState, useEffect } from 'react';
+import { addAsset, getCoins } from '../api';
 import { toast } from 'react-toastify';
 
 export default function AddAssetForm({ onAdd }) {
   const [symbol, setSymbol] = useState('');
   const [quantity, setQuantity] = useState('');
   const [buyPrice, setBuyPrice] = useState('');
+  const [coins, setCoins] = useState([]);
   const [errors, setErrors] = useState({ quantity: false, buyPrice: false });
   const [errorMsg, setErrorMsg] = useState('');
+
+  useEffect(() => {
+    async function loadCoins() {
+      try {
+        const res = await getCoins();
+        setCoins(res.data);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    loadCoins();
+  }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -43,7 +56,8 @@ export default function AddAssetForm({ onAdd }) {
   return (
     <form onSubmit={handleSubmit}>
       <input
-        placeholder="Symbol (e.g. bitcoin - lowercase)"
+        list="coin-options"
+        placeholder="Symbol (e.g. bitcoin)"
         value={symbol}
         onChange={e => setSymbol(e.target.value)}
         required
@@ -66,6 +80,13 @@ export default function AddAssetForm({ onAdd }) {
       />
       <button type="submit">Add Asset</button>
       {errorMsg && <p className="error-message">{errorMsg}</p>}
+      <datalist id="coin-options">
+        {coins.map((c) => (
+          <option key={c.id} value={c.id}>
+            {c.name} ({c.symbol})
+          </option>
+        ))}
+      </datalist>
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- fetch supported coin list from CoinGecko
- expose `/coins` endpoint from Flask backend
- add client API wrapper for coins
- provide datalist-based autocomplete in `AddAssetForm`

## Testing
- `npm --prefix frontend run lint`
- `python -m py_compile backend/app.py backend/services/coingecko.py backend/models.py`

------
https://chatgpt.com/codex/tasks/task_e_684680c648fc832c909c74317e08a9f7